### PR TITLE
[서인] 5-4. 연속 부분수열2

### DIFF
--- a/05. 효율성(투포인터 알고리즘, 슬라이디윈도우, 해쉬)/04. 연속부분수열2/이서인/index.js
+++ b/05. 효율성(투포인터 알고리즘, 슬라이디윈도우, 해쉬)/04. 연속부분수열2/이서인/index.js
@@ -1,5 +1,20 @@
 function solution(m, arr) {
   let answer = 0;
+  let pointer1 = 0;
+  let pointer2 = 0;
+  let sum = 0;
+
+  while (pointer2 < arr.length) {
+    sum += arr[pointer2++];
+
+    while (pointer1 < pointer2 && sum > m) {
+      sum -= arr[pointer1++];
+    }
+
+    if (sum <= m) {
+      answer += pointer2 - pointer1;
+    }
+  }
 
   return answer;
 }


### PR DESCRIPTION
✔ 문제 제목: 연속 부분수열2

✔ 문제 유형: 슬라이딩 윈도우

✔ 문제 풀이 날짜: 2024.07.30

## 💡 문제 분석 요약

- n개의 숫자 배열 중 연속 부분수열 합이 m이하인 경우의 수를 구해야 한다.

## 💡 알고리즘 설계

- 답, 포인터, sum을 변수로 선언한다.
- pointer2가 배열 길이보다 작을 때 pointer2 인덱스 요소를 sum에 더하고, pointer2에 1을 더한다.
- pointer1이 pointer2보다 작고, sum이 m보다 클 때 sum에서 pointer1 인덱스 요소를 뺀다.
- sum이 m 이하일 때 pointer2에서 pointer1을 빼서 조건에 만족하는 sum의 수를 한 번에 구한다.

## 💡코드

```javascript
function solution(m, arr) {
let answer = 0;
let pointer1 = 0;
let pointer2 = 0;
let sum = 0;

while(pointer2 < arr.length) {
sum += arr[pointer2++];

while(pointer1 < pointer2 && sum > m) {
sum -= arr[pointer2++];
}

if(sum <= m) {
answer += pointer2 - pointer1;
}
}
return answer;
}
```

## 💡 시간복잡도

O(n)

## 💡 틀린 이유와 틀린 부분 수정 or 다른 풀이

- pointer2 - pointer1이 m이하의 부분수열 합의 개수를 한 번에 구하는 공식이 되는 줄 몰랐다.

```javascript
// 다른 풀이를 작성해주세요 !
```

## 💡 느낀 점 or 기억할 정보

- 풀이 방식을 외웠는데, 같은 유형 문제를 과연 풀 수 있을까요...ㅎㅎ
