### PR TITLE
[윤아영] 8-5 합이 같은 부분집합(복습예정)

### DIFF
--- a/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/05. 합이 같은 부분집합/윤아영/index.js
+++ b/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/05. 합이 같은 부분집합/윤아영/index.js
@@ -1,5 +1,24 @@
 function solution(arr) {
-  let answer = 'NO';
+  let answer = "NO";
+  const sum = arr.reduce((acc, cur) => acc + cur, 0);
+
+  const DFS = (index, path) => {
+    const subsetSum = path.reduce((acc, cur) => acc + cur, 0);
+    if (subsetSum === sum - subsetSum) {
+      answer = "YES";
+      return true;
+    }
+
+    for (let i = index; i < arr.length; i++) {
+      if (DFS(i + 1, path.concat([arr[i]]))) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  DFS(0, []);
 
   return answer;
 }


### PR DESCRIPTION
✔ 문제 제목: 합이 같은 부분집합

✔ 문제 유형: DFS

✔ 문제 풀이 날짜: 24-08-22

## 💡 문제 분석 요약
- N개의 원소로 구성된 자연수 집합이 주어진다
- 두 개의 부분 집합으로 나누고 두 부분집합의 원소의 합이 서로 같은 경우가 존재하면 "YES" 아니면 "NO"를 출력한다.
- 두 개의 부분집합은 서로소 집합이다.
- 서로소 집합: 공통 원소가 없는 집합

## 💡 알고리즘 설계

- 부분 집합을 출력하는 것과 비슷합니다. 
- 전체합에서 부분집합(path) 합의 제외했을 때 path의 원소 합계와 같다면 "YES"가 반환되도록 합니다.
- 대신 조건에 만족하는 경우 true를 반환하여 얼리 리턴할 수 있도록 하였습니다.

## 💡코드

```javascript
function solution(arr) {
  let answer = "NO";
  const sum = arr.reduce((acc, cur) => acc + cur, 0);

  const DFS = (index, path) => {
    const subsetSum = path.reduce((acc, cur) => acc + cur, 0);
    if (subsetSum === sum - subsetSum) {
      answer = "YES";
      return true;
    }

    for (let i = index; i < arr.length; i++) {
      if (DFS(i + 1, path.concat([arr[i]]))) {
        return true;
      }
    }

    return false;
  };

  DFS(0, []);

  return answer;
}

let arr = [1, 3, 5, 6, 7, 10];
console.log(solution(arr));
```

## 💡 느낀 점 or 기억할 정보

- 함수를 재귀적으로 호출하다보니 그냥 return true를 하면 얼리리턴을 할 수 없고 그 상위 재귀 함수에서도 return 할 수 있도록 해야했습니다.
