### PR TITLE
[서인] 8-8. 중복순열(9/11 복습 예정)

### DIFF
--- a/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/07. 최대점수 구하기/이서인/index.js
+++ b/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/07. 최대점수 구하기/이서인/index.js
@@ -1,5 +1,19 @@
 function solution(m, ps, pt) {
   let answer = Number.MIN_SAFE_INTEGER;
+  
+  function DFS(index, currentTime, currentScore) {
+
+    if (currentTime > m) return;
+
+    answer = Math.max(answer, currentScore)
+
+    if (index === pt.length) return;
+
+    DFS(index + 1, currentTime + pt[index], currentScore + ps[index])
+    DFS(index + 1, currentTime, currentScore)
+  }
+
+  DFS(0, 0, 0)
 
   return answer;
 }

--- a/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/08. 중복순열/이서인/index.js
+++ b/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/08. 중복순열/이서인/index.js
@@ -1,12 +1,11 @@
 function solution(n, m) {
   let answer = [];
 
-  function DFS(depth, part = "") {
-    if (depth === m) return part && answer.push(part)
+  function DFS(numbers, part = "") {
+    if (numbers === m) return part && answer.push(part)
     Array.from({ length: n }, (_, i) => i + 1).forEach((el) => {
-      DFS(depth + 1, part + el)
+      DFS(numbers + 1, part + el)
     })
-
   }
   DFS(0, "");
 

--- a/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/08. 중복순열/이서인/index.js
+++ b/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/08. 중복순열/이서인/index.js
@@ -1,7 +1,16 @@
 function solution(n, m) {
   let answer = [];
 
-  return answer;
+  function DFS(depth, part = "") {
+    if (depth === m) return part && answer.push(part)
+    Array.from({ length: n }, (_, i) => i + 1).forEach((el) => {
+      DFS(depth + 1, part + el)
+    })
+
+  }
+  DFS(0, "");
+
+  return answer.join("\n") + "\n" + answer.length;
 }
 
 console.log(solution(3, 2));


### PR DESCRIPTION
✔ 문제 제목: 중복순열

✔ 문제 유형: 재귀함수

✔ 문제 풀이 날짜: 2024.09.04

## 💡 문제 분석 요약

- 1부터 n까지 적힌 구슬을 m번 뽑는 모든 경우의 수를 구해야 한다.
- 구슬은 한 번 뽑고, 다시 넣어서 뽑는다.(중복 가능)

## 💡 알고리즘 설계

- 선택한 숫자 numbers가 m개가 되면 answer 집합에 push한다.
- 길이가 n인 배열을 생성해 forEach로 조합에 배열 요소를 추가한다.

## 💡코드

```javascript
function solution(n, m) {
  let answer = [];

  function DFS(numbers, part = "") {
    if (numbers === m) return part && answer.push(part)
    Array.from({ length: n }, (_, i) => i + 1).forEach((el) => {
      DFS(numbers + 1, part + el)
    })
  }
  DFS(0, "");

  return answer.join("\n") + "\n" + answer.length;
}
```

## 💡 시간복잡도

O(n^m)

## 💡 틀린 이유와 틀린 부분 수정 or 다른 풀이

- 기존 풀이 방식을 적용할 수 없어서 풀기 어려웠습니다.

```javascript
function solution2(n, m) {
  let answer = [];

  function DFS(idx, arr) {
    if (idx === m) {
      answer.push(arr);
      return;
    }

    for (let i = 1; i <= n; i++) {
      DFS(idx + 1, [...arr, i]);
    }
  }

  DFS(0, []);

  answer.push(answer.length);

  return answer;
}

console.log(solution2(3, 2)); // [[1, 1], [1, 2], [1, 3], [2, 1], [2, 2], [2, 3], [3, 1], [3, 2], [3, 3]] 9
console.log(solution2(4, 3)); // [[1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 1, 4], [1, 2, 1], ...] 64
```

## 💡 느낀 점 or 기억할 정보

- GPT 도움을 이해하는 데에도 좀 오래 걸리는 군요.
