### PR TITLE
[서인] 9-3. 경로탐색(인접리스트)

### DIFF
--- a/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/10. 순열 구하기/이서인/index.js
+++ b/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/10. 순열 구하기/이서인/index.js
@@ -1,7 +1,15 @@
 function solution(m, arr) {
   let answer = [];
 
-  return answer;
+  function DFS(index, part = "") {
+    if (part.length > 1 && part[0] === part[1]) return;
+    if (index === m) return part && answer.push(part);
+    arr.forEach(el => {
+      DFS(index + 1, part + el)
+    })
+  }
+  DFS(0, "")
+  return answer.join("\n") + "\n" + answer.length;
 }
 
 let arr = [3, 6, 9];

--- a/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/11. 팩토리얼/이서인/index.js
+++ b/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/11. 팩토리얼/이서인/index.js
@@ -1,9 +1,6 @@
 function solution(n) {
-  function DFS(n) {
     if (n === 1) return 1;
-    return n * DFS(n - 1)
-  }
-  return DFS(n)
+    return n * solution(n - 1)
 }
 
 console.log(solution(5));

--- a/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/11. 팩토리얼/이서인/index.js
+++ b/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/11. 팩토리얼/이서인/index.js
@@ -1,7 +1,9 @@
 function solution(n) {
-  let answer;
-
-  return answer;
+  function DFS(n) {
+    if (n === 1) return 1;
+    return n * DFS(n - 1)
+  }
+  return DFS(n)
 }
 
 console.log(solution(5));

--- a/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/13. 수열 추측하기/이서인/index.js
+++ b/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/13. 수열 추측하기/이서인/index.js
@@ -1,7 +1,40 @@
 function solution(n, f) {
-  let answer;
+  let answer = null;
+  let flag = false;
+  let dy = Array.from(Array(n + 1), () => Array(n + 1).fill(0));
+  let ch = Array(n + 1).fill(0);
+  let p = Array(n);
+  let b = Array(n);
 
-  return answer;
+  function combi(n, r) {
+    if (dy[n][r] > 0) return dy[n][r]; //메모이제이션
+    if (n === r || r === 0) return 1;
+    return dy[n][r] = combi(n - 1, r - 1) + combi(n - 1, r);
+  }
+
+  function DFS(L, sum) {
+    if (flag) return;
+    if (L === n && sum === f) {
+      answer = p.slice();
+      flag = true;
+    } else {
+      for (let i = 1; i <= n; i++) {
+        if (ch[i] === 0) {
+          ch[i] = 1;
+          p[L] = i;
+          DFS(L + 1, sum + b[L] * p[L]);
+          ch[i] = 0;
+        }
+      }
+    }
+  }
+  for (let i = 0; i < n; i++) {
+    b[i] = combi(n - 1, i);
+  }
+
+  DFS(0, 0);
+
+  return answer.join(' ');
 }
 
 console.log(solution(4, 16));

--- a/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/14. 조합 구하기/이서인/index.js
+++ b/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/14. 조합 구하기/이서인/index.js
@@ -1,7 +1,20 @@
 function solution(n, m) {
-  let answer = [];
+  let elements = new Set()
+  
+  function DFS(el, part = "") {
+    if (part.length === m) {
+      elements.add(part);
+      return;
+    }
+    if (el > n) return;
+    
+    DFS(el + 1, part + el)
+    DFS(el + 1, part);
+  }
+  
+  DFS(1);
 
-  return answer;
+  return [...elements, [...elements].length].join("\n")
 }
 
 console.log(solution(4, 2));

--- a/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/14. 조합 구하기/이서인/index.js
+++ b/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/14. 조합 구하기/이서인/index.js
@@ -1,9 +1,9 @@
 function solution(n, m) {
-  let elements = new Set()
+  let elements = []
   
   function DFS(el, part = "") {
     if (part.length === m) {
-      elements.add(part);
+      elements.push(part);
       return;
     }
     if (el > n) return;
@@ -14,7 +14,7 @@ function solution(n, m) {
   
   DFS(1);
 
-  return [...elements, [...elements].length].join("\n")
+  return [...elements, elements.length].join("\n")
 }
 
 console.log(solution(4, 2));

--- a/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/15. 수들의 조합/이서인/index.js
+++ b/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/15. 수들의 조합/이서인/index.js
@@ -1,7 +1,20 @@
 function solution(n, k, arr, m) {
-  let answer = 0;
+  let parts = [];
 
-  return answer;
+  function DFS(index, part = [], count = 0) {
+    if (count === k) {
+      parts.push(part.slice());
+      return;
+    }
+    if (index >= n) return;
+
+    DFS(index + 1, part.concat(arr[index]), count + 1);
+    DFS(index + 1, part, count);
+  }
+
+  DFS(0,[])
+
+  return parts.filter(el => el.reduce((a, b) => a + b, 0) % m === 0).length
 }
 
 let arr = [2, 4, 5, 8, 12];

--- a/09. 그래프와 탐색(DFS, BFS;너비우선탐색)/02. 경로탐색(DFS)/이서인/index.js
+++ b/09. 그래프와 탐색(DFS, BFS;너비우선탐색)/02. 경로탐색(DFS)/이서인/index.js
@@ -1,5 +1,29 @@
 function solution(n, arr) {
   let answer = 0;
+  const graph = Array.from({ length: n + 1 }, () => new Array(n + 1).fill(0));
+  const visited = new Array(n + 1).fill(false);
+
+  for (const [s, e] of arr) {
+    graph[s][e] = 1;
+  }
+
+  function DFS(v) {
+    if (v === n) {
+      answer++;
+      return;
+    }
+
+    for (let i = 1; i <= n; i++) {
+      if (graph[v][i] === 1 && !visited[i]) {
+        visited[i] = true;
+        DFS(i);
+        visited[i] = false;
+      }
+    }
+  }
+
+  visited[1] = true;
+  DFS(1);
 
   return answer;
 }

--- a/09. 그래프와 탐색(DFS, BFS;너비우선탐색)/03. 경로탐색(인접리스트)/이서인/index.js
+++ b/09. 그래프와 탐색(DFS, BFS;너비우선탐색)/03. 경로탐색(인접리스트)/이서인/index.js
@@ -1,6 +1,31 @@
 function solution(n, arr) {
   let answer = 0;
+  const graph = Array.from({length: n + 1}, () => [])
+  const visited = new Array(n + 1).fill(false)
 
+  for (const [s, e] of arr) {
+    graph[s].push(e)
+  }
+
+  function DFS(v) {
+    if (v === n) {
+      answer++
+      return
+    }
+      
+      visited[v] = true;
+  
+      for (const next of graph[v]) {
+        if (!visited[next]) {
+          DFS(next)
+        }
+      }
+    
+    visited[v] = false
+  }
+
+  DFS(1) 
+  
   return answer;
 }
 


### PR DESCRIPTION
✔ 문제 제목: 경로탐색(인접리스트)

✔ 문제 유형: DFS

✔ 문제 풀이 날짜: 2024.09.11

## 💡 문제 분석 요약

- 인접리스트 방식으로 정점 n까지의 모든 경로의 수를 구한다.

## 💡 알고리즘 설계

- 인접 리스트를 생성한다.
- 방문을 기록하는 배열을 생성한다.
- 주어진 배열의 시작 노드와 끝 노드를 순회하면서 시작 노드와 끝 노드를 연결하는 경로를 인접리스트에 추가한다.
- DFS 함수
  - 매개변수가 n과 같을 때 answer에 1을 추가하고 함수를 종료한다.
  - 현재 노드를 방문한 노드로 재할당한다.
  - 인접리스트의 현재 노드 중 방문하지 않은 노드에서 재귀 호출로 다음 노드를 탐색한다.
  - 백트래킹을 위해 방문하지 않은 노드로 재할당한다.
  - DFS 초기값을 호출한다. 

## 💡코드

```javascript
// 여기에 코드 작성해주세요 !
```

## 💡 시간복잡도

O(2^n)

## 💡 틀린 이유와 틀린 부분 수정 or 다른 풀이

-

```javascript
function solution(n, arr) {
  let answer = 0;
  const graph = Array.from({length: n + 1}, () => [])
  const visited = new Array(n + 1).fill(false)

  for (const [s, e] of arr) {
    graph[s].push(e)
  }

  function DFS(v) {
    if (v === n) {
      answer++
      return
    }
      
      visited[v] = true;
  
      for (const next of graph[v]) {
        if (!visited[next]) {
          DFS(next)
        }
      }
    
    visited[v] = false
  }

  DFS(1) 
  
  return answer;
}
```

## 💡 느낀 점 or 기억할 정보

- 기본 구조를 익혔으니 응용문제도 쑥쑥 풀고 싶어요!
