### PR TITLE
[지원] 8-3. 이진트리순회

### DIFF
--- a/07. 정렬과 그리디, 결정알고리즘(이분검색)/12. 마구간 정하기/백지원/index.js
+++ b/07. 정렬과 그리디, 결정알고리즘(이분검색)/12. 마구간 정하기/백지원/index.js
@@ -1,5 +1,37 @@
 function solution(c, stable) {
-  let answer;
+  stable.sort((a, b) => a - b);
+
+  let start = 1;
+  end = stable[stable.length - 1] - stable[0];
+  let answer = 0;
+
+  // 주어진 거리 d로 c마리 말을 배치할 수 있는지 확인하는 함수
+  function canPlaceHorses(d) {
+    let count = 1; // 첫 번째 말 배치
+    let lastPosition = stable[0]; // 첫 번째 말의 위치
+
+    // 두 번째 마구간 부터 반복
+    for (let i = 1; i < stable.length; i++) {
+      if (stable[i] - lastPosition >= d) {
+        count++; // 말 배치
+        lastPosition = stable[i]; // 마지막 배치된 위치 갱신
+        if (count === c) return true;
+      }
+    }
+
+    return false; // 배치 불가능
+  }
+
+  while (start <= end) {
+    let mid = Math.floor((start + end) / 2);
+
+    if (canPlaceHorses(mid)) {
+      answer = mid;
+      start = mid + 1; // 최대니까 더 큰 거리 탐색
+    } else {
+      end = mid - 1;
+    }
+  }
 
   return answer;
 }

--- a/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/01. 재귀함수/백지원/index.js
+++ b/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/01. 재귀함수/백지원/index.js
@@ -1,5 +1,9 @@
 function solution(n) {
-  function DFS(L) {}
+  function DFS(L) {
+    if (L === 0) return;
+    DFS(L - 1);
+    console.log(L);
+  }
   DFS(n);
 }
 

--- a/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/02. 이진수 출력(재귀)/백지원/index.js
+++ b/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/02. 이진수 출력(재귀)/백지원/index.js
@@ -1,7 +1,13 @@
 function solution(n) {
-  let answer = '';
+  let answer = [];
 
-  return answer;
+  function DFS(n) {
+    if (n === 0) return;
+    DFS(Math.floor(n / 2));
+    answer.push(n % 2);
+  }
+  DFS(n);
+  return answer.join("");
 }
 
 console.log(solution(11));

--- a/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/03. 이진트리순회/백지원/index.js
+++ b/08. 재귀함수와 완전탐색(DFS;깊이우선탐색)/03. 이진트리순회/백지원/index.js
@@ -1,6 +1,35 @@
 function solution(n) {
-  let answer = '';
+  let answer = {
+    preOrder: "",
+    postOrder: "",
+  };
 
+  const tree = {
+    1: [2, 3],
+    2: [4, 5],
+    3: [6, 7],
+    4: [null, null],
+    5: [null, null],
+    6: [null, null],
+    7: [null, null],
+  };
+
+  function preOrder(node) {
+    if (!node) return; // 기저조건
+    answer.preOrder += node + " "; // 현재 노드 번호 추가
+    preOrder(tree[node][0]); // 왼쪽 자식을 재귀 호출
+    preOrder(tree[node][1]); // 오른쪽 자식을 재귀 호출
+  }
+
+  function postOrder(node) {
+    if (!node) return;
+    postOrder(tree[node][0]);
+    postOrder(tree[node][1]);
+    answer.postOrder += node + " ";
+  }
+
+  preOrder(n);
+  postOrder(n);
   return answer;
 }
 


### PR DESCRIPTION
✔ 문제 제목: 이진트리순회

✔ 문제 유형: 재귀

✔ 문제 풀이 날짜: 11.21

## 💡 문제 분석 요약
전위순회, 후위순회 출력

## 💡 알고리즘 설계

- 전위순회는 현재 노드 번호를 추가하고 왼쪽 자식 재귀호출, 오른쪽 자식 재귀호출
- 후위 순회는 왼쪽 자식 재귀호출, 오른쪽 자식 재귀호출하고 현재 노드번호 추가

## 💡코드

```javascript
function solution(n) {
  let answer = {
    preOrder: "",
    postOrder: "",
  };

  const tree = {
    1: [2, 3],
    2: [4, 5],
    3: [6, 7],
    4: [null, null],
    5: [null, null],
    6: [null, null],
    7: [null, null],
  };

  function preOrder(node) {
    if (!node) return; // 기저조건
    answer.preOrder += node + " "; // 현재 노드 번호 추가
    preOrder(tree[node][0]); // 왼쪽 자식을 재귀 호출
    preOrder(tree[node][1]); // 오른쪽 자식을 재귀 호출
  }

  function postOrder(node) {
    if (!node) return;
    postOrder(tree[node][0]);
    postOrder(tree[node][1]);
    answer.postOrder += node + " ";
  }

  preOrder(n);
  postOrder(n);
  return answer;
}

console.log(solution(1));


## 💡 시간복잡도
O(N) => 트리의 모든 노드를 정확히 한 번 방문하므로, 시간복잡도는 노드의 수 N에 비례

## 💡 느낀 점 or 기억할 정보

- 재귀 어려워요 🍃
